### PR TITLE
Fix for livewire form properties not being found.

### DIFF
--- a/app/DataStore.php
+++ b/app/DataStore.php
@@ -70,6 +70,19 @@ class DataStore
         return $matchingComponent;
     }
 
+    public function findComponentForClass(string $className): ?BladeComponentData
+    {
+        $matchingComponent = null;
+
+        foreach ($this->availableComponents as $component) {
+            if ($component->matchesClass($className)) {
+                $matchingComponent = $component;
+                break;
+            }
+        }
+        return $matchingComponent;
+    }
+
     public function refreshAvailableComponents(bool $force = false): Collection
     {
         if (self::$inprogress === false && ($this->availableComponents->isEmpty() || $force)) {

--- a/app/Dto/BladeComponentData.php
+++ b/app/Dto/BladeComponentData.php
@@ -31,6 +31,12 @@ class BladeComponentData
         return false;
     }
 
+    // Check if the view file is from this component.
+    public function matchesClass(string $className): bool
+    {
+        return $this->class === $className;
+    }
+
     public function getHoverData(): string
     {
         return $this->doc ?? $this->getFile() ?? $this->class ?? '';

--- a/app/Lsp/LspValidators/LivewireLspValidate.php
+++ b/app/Lsp/LspValidators/LivewireLspValidate.php
@@ -31,6 +31,17 @@ class LivewireLspValidate extends BaseLspValidator
                 ]);
             }
 
+            $nestedProps = [];
+            foreach ($component->wireProps as $prop => $className) {
+                $nestedComponent = $this->store->findComponentForClass('\\' . $className);
+                if (!$nestedComponent) {
+                    continue;
+                }
+                foreach (array_keys($nestedComponent->wireProps) as $nestedProp) {
+                    $nestedProps[] = $prop . '.' . $nestedProp;
+                }
+            }
+
             $wireModels = $workableArray
                 ->filter(function ($item) {
                     // Only get models.
@@ -39,7 +50,12 @@ class LivewireLspValidate extends BaseLspValidator
                 ->filter(function ($item) use ($component) {
                     // Check if they are in the list.
                     return !array_key_exists($item['name'], $component->wireProps);
+                })
+                ->filter(function ($item) use ($nestedProps) {
+                    // Check if they are nested.
+                    return !in_array($item['name'], $nestedProps);
                 });
+
 
             foreach ($wireModels as $missingWireable) {
                 $errors[] = new DiagnosticError(


### PR DESCRIPTION
Fix for nested livewire form properties not being found as discussed in issue https://github.com/haringsrob/laravel-dev-tools/issues/15. Tried to be as unobtrusive as possible. Additional reflection was not necessary since "DataStore" already holds the "BladeComponentData" for Livewire forms. 

Only issue is that this fix only supports one level of nesting and the class with the nested properties must also be a Livewire component. I could have made a recursive function and implemented actual reflection for classes not found in the "availableComponents" array, but I don't think that is a good idea. This should be fine since it doesn't support bad programming practices with Livewire. Livewire properties really shouldn't be nested more than one level deep, and they really should be in a Livewire form if they are nested.

Lastly, I wanted to write a test but ran into this issue. Didn't look that deep into it but if it is a simple fix let me know.

![image](https://github.com/haringsrob/laravel-dev-tools/assets/11857985/0c5491b0-1fac-4e7a-8d6a-ceab6fb99924)
